### PR TITLE
Rendered Meshes now respect the gameObject's layer

### DIFF
--- a/Assets/Vive-Teleporter/Scripts/BorderRenderer.cs
+++ b/Assets/Vive-Teleporter/Scripts/BorderRenderer.cs
@@ -22,8 +22,6 @@ public class BorderRenderer : MonoBehaviour {
     [Tooltip("Layer to render the mesh at.")]
     private int AlphaShaderID = -1;
     
-    public int RenderLayer = 0;
-
     /// Polylines that will be drawn.
     public BorderPointSet[] Points {
         get
@@ -66,7 +64,7 @@ public class BorderRenderer : MonoBehaviour {
         }
 
         foreach (Mesh m in CachedMeshes)
-            Graphics.DrawMesh(m, Transpose, BorderMaterial, RenderLayer, null, 0, null, false, false);
+            Graphics.DrawMesh(m, Transpose, BorderMaterial, gameObject.layer, null, 0, null, false, false);
     }
 
     void OnValidate()

--- a/Assets/Vive-Teleporter/Scripts/BorderRenderer.cs
+++ b/Assets/Vive-Teleporter/Scripts/BorderRenderer.cs
@@ -19,7 +19,10 @@ public class BorderRenderer : MonoBehaviour {
     public float BorderAlpha = 1.0f;
     private float LastBorderAlpha = 1.0f;
 
+    [Tooltip("Layer to render the mesh at.")]
     private int AlphaShaderID = -1;
+    
+    public int RenderLayer = 0;
 
     /// Polylines that will be drawn.
     public BorderPointSet[] Points {
@@ -63,7 +66,7 @@ public class BorderRenderer : MonoBehaviour {
         }
 
         foreach (Mesh m in CachedMeshes)
-            Graphics.DrawMesh(m, Transpose, BorderMaterial, 0, null, 0, null, false, false);
+            Graphics.DrawMesh(m, Transpose, BorderMaterial, RenderLayer, null, 0, null, false, false);
     }
 
     void OnValidate()

--- a/Assets/Vive-Teleporter/Scripts/ParabolicPointer.cs
+++ b/Assets/Vive-Teleporter/Scripts/ParabolicPointer.cs
@@ -29,9 +29,13 @@ public class ParabolicPointer : MonoBehaviour {
     [Tooltip("Material to use for the inside of the bottom of the selection pad")]
     public Material SelectionPadBottomMaterial;
 
+    [Tooltip("Target layer to render at.")]
+    public int RenderLayer = 0;
+
     public Vector3 SelectedPoint { get; private set; }
     public bool PointOnNavMesh { get; private set; }
     public float CurrentParabolaAngle { get; private set; }
+
 
     private Mesh ParabolaMesh;
 
@@ -200,21 +204,21 @@ public class ParabolicPointer : MonoBehaviour {
         if (ShouldDrawMarker)
         {
             // Draw Inside of Selection pad
-            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadFadeMaterial, 0, null, 3);
+            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadFadeMaterial, RenderLayer, null, 3);
             // Draw Bottom of selection pad
-            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadCircleMaterial, 0, null, 1);
+            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadCircleMaterial, RenderLayer, null, 1);
             // Draw Bottom of selection pad
-            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadBottomMaterial, 0, null, 2);
+            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadBottomMaterial, RenderLayer, null, 2);
         }
 
         // Draw parabola (BEFORE the outside faces of the selection pad, to avoid depth issues)
         GenerateMesh(ref ParabolaMesh, ParabolaPoints, velocity, Time.time % 1);
 
         // Draw outside faces of selection pad AFTER parabola (it is drawn on top)
-        Graphics.DrawMesh(ParabolaMesh, Matrix4x4.identity, GraphicMaterial, 0);
+        Graphics.DrawMesh(ParabolaMesh, Matrix4x4.identity, GraphicMaterial, RenderLayer);
 
         if (ShouldDrawMarker)
-            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadFadeMaterial, 0, null, 0);
+            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadFadeMaterial, RenderLayer, null, 0);
     }
     
     // Used when you can't depend on Update() to automatically update CurrentParabolaAngle

--- a/Assets/Vive-Teleporter/Scripts/ParabolicPointer.cs
+++ b/Assets/Vive-Teleporter/Scripts/ParabolicPointer.cs
@@ -28,10 +28,7 @@ public class ParabolicPointer : MonoBehaviour {
     public Material SelectionPadCircleMaterial;
     [Tooltip("Material to use for the inside of the bottom of the selection pad")]
     public Material SelectionPadBottomMaterial;
-
-    [Tooltip("Target layer to render at.")]
-    public int RenderLayer = 0;
-
+    
     public Vector3 SelectedPoint { get; private set; }
     public bool PointOnNavMesh { get; private set; }
     public float CurrentParabolaAngle { get; private set; }
@@ -204,21 +201,21 @@ public class ParabolicPointer : MonoBehaviour {
         if (ShouldDrawMarker)
         {
             // Draw Inside of Selection pad
-            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadFadeMaterial, RenderLayer, null, 3);
+            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadFadeMaterial, gameObject.layer, null, 3);
             // Draw Bottom of selection pad
-            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadCircleMaterial, RenderLayer, null, 1);
+            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadCircleMaterial, gameObject.layer, null, 1);
             // Draw Bottom of selection pad
-            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadBottomMaterial, RenderLayer, null, 2);
+            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadBottomMaterial, gameObject.layer, null, 2);
         }
 
         // Draw parabola (BEFORE the outside faces of the selection pad, to avoid depth issues)
         GenerateMesh(ref ParabolaMesh, ParabolaPoints, velocity, Time.time % 1);
 
         // Draw outside faces of selection pad AFTER parabola (it is drawn on top)
-        Graphics.DrawMesh(ParabolaMesh, Matrix4x4.identity, GraphicMaterial, RenderLayer);
+        Graphics.DrawMesh(ParabolaMesh, Matrix4x4.identity, GraphicMaterial, gameObject.layer);
 
         if (ShouldDrawMarker)
-            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadFadeMaterial, RenderLayer, null, 0);
+            Graphics.DrawMesh(SelectionPadMesh, Matrix4x4.TRS(SelectedPoint + Vector3.up * 0.005f, Quaternion.identity, Vector3.one * 0.2f), SelectionPadFadeMaterial, gameObject.layer, null, 0);
     }
     
     // Used when you can't depend on Update() to automatically update CurrentParabolaAngle

--- a/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
+++ b/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
@@ -116,7 +116,7 @@ public class ViveNavMesh : MonoBehaviour
     {
         // We have to use command buffers instead of Graphics.DrawMesh because of strange depth issues that I am experiencing
         // with Graphics.Drawmesh (perhaps Graphics.DrawMesh is called before all opaque objects are rendered?)
-        var act = gameObject.activeInHierarchy && enabled;
+        var act = gameObject.activeInHierarchy && enabled && (gameObject.layer & Camera.current.cullingMask) != 0;
         if (!act)
         {
             Cleanup();

--- a/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
+++ b/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
@@ -116,7 +116,7 @@ public class ViveNavMesh : MonoBehaviour
     {
         // We have to use command buffers instead of Graphics.DrawMesh because of strange depth issues that I am experiencing
         // with Graphics.Drawmesh (perhaps Graphics.DrawMesh is called before all opaque objects are rendered?)
-        var act = gameObject.activeInHierarchy && enabled && (gameObject.layer & Camera.current.cullingMask) != 0;
+        var act = gameObject.activeInHierarchy && enabled;
         if (!act)
         {
             Cleanup();
@@ -128,7 +128,7 @@ public class ViveNavMesh : MonoBehaviour
             return;
 
         var cam = Camera.current;
-        if (!cam || cam.cameraType == CameraType.Preview)
+        if (!cam || cam.cameraType == CameraType.Preview || ((1 << gameObject.layer) & Camera.current.cullingMask) == 0)
             return;
 
         CommandBuffer buf = null;


### PR DESCRIPTION
I just changed the rendering scripts to use the gameObject's layer to render at, instead of defaulting to layer 0.
I did this in order to be able to hide the teleporting graphics in other cameras in a split-screen multiplayer environment.
