### PR TITLE
Fixed issue with chaperone border renderer

### DIFF
--- a/Assets/Vive-Teleporter/Scripts/TeleportVive.cs
+++ b/Assets/Vive-Teleporter/Scripts/TeleportVive.cs
@@ -77,13 +77,15 @@ public class TeleportVive : MonoBehaviour {
         Vector3 p0, p1, p2, p3;
         if (GetChaperoneBounds(out p0, out p1, out p2, out p3))
         {
+            // Rotate to match camera rig rotation
+            var originRotationMatrix = Matrix4x4.TRS(Vector3.zero, OriginTransform.rotation, Vector3.one);
+
             BorderPointSet p = new BorderPointSet(new Vector3[] {
-                // Rotate to match camera rig rotation
-                Matrix4x4.TRS(Vector3.zero, OriginTransform.rotation, Vector3.one) * p0,
-                Matrix4x4.TRS(Vector3.zero, OriginTransform.rotation, Vector3.one) * p1,
-                Matrix4x4.TRS(Vector3.zero, OriginTransform.rotation, Vector3.one) * p2,
-                Matrix4x4.TRS(Vector3.zero, OriginTransform.rotation, Vector3.one) * p3,
-                Matrix4x4.TRS(Vector3.zero, OriginTransform.rotation, Vector3.one) * p0,
+                originRotationMatrix * p0,
+                originRotationMatrix * p1,
+                originRotationMatrix * p2,
+                originRotationMatrix * p3,
+                originRotationMatrix * p0,
             });
             RoomBorder.Points = new BorderPointSet[]
             {

--- a/Assets/Vive-Teleporter/Scripts/TeleportVive.cs
+++ b/Assets/Vive-Teleporter/Scripts/TeleportVive.cs
@@ -78,8 +78,13 @@ public class TeleportVive : MonoBehaviour {
         if (GetChaperoneBounds(out p0, out p1, out p2, out p3))
         {
             BorderPointSet p = new BorderPointSet(new Vector3[] {
-                    p0, p1, p2, p3, p0
-                });
+                // Rotate to match camera rig rotation
+                Matrix4x4.TRS(Vector3.zero, OriginTransform.rotation, Vector3.one) * p0,
+                Matrix4x4.TRS(Vector3.zero, OriginTransform.rotation, Vector3.one) * p1,
+                Matrix4x4.TRS(Vector3.zero, OriginTransform.rotation, Vector3.one) * p2,
+                Matrix4x4.TRS(Vector3.zero, OriginTransform.rotation, Vector3.one) * p3,
+                Matrix4x4.TRS(Vector3.zero, OriginTransform.rotation, Vector3.one) * p0,
+            });
             RoomBorder.Points = new BorderPointSet[]
             {
                 p


### PR DESCRIPTION
Fixed issue where chaperone border renderer would be rotated incorrectly
if the camera rig (origin transform) had a rotation other than 0. This
is necessary for situations where the chaperone has to match the
orientation of elements of the world, but it is impossible to rotate the
whole world (e.g. Unity terrain)
