### PR TITLE
Ignore Triggers when doing the Raycast

### DIFF
--- a/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
+++ b/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
@@ -41,15 +41,15 @@ public class ViveNavMesh : MonoBehaviour
         set {  _LayerMask = value; }
     }
     [SerializeField]
-    private int _LayerMask;
+    private int _LayerMask = 0;
 
-    public QueryTriggerInteraction QueryTriggerInteraction
+    public int QueryTriggerInteraction
     {
         get { return _QueryTriggerInteraction; }
         set { _QueryTriggerInteraction = value; }
     }
     [SerializeField]
-    private QueryTriggerInteraction _QueryTriggerInteraction;
+    private int _QueryTriggerInteraction = 0;
 
     /// A Mesh that represents the "Selectable" area of the world.  This is converted from Unity's NavMesh in ViveNavMeshEditor
     public Mesh SelectableMesh

--- a/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
+++ b/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
@@ -35,6 +35,22 @@ public class ViveNavMesh : MonoBehaviour
     private float LastGroundAlpha = 1.0f;
     private int AlphaShaderID = -1;
 
+    public int LayerMask
+    {
+        get { return _LayerMask;  }
+        set {  _LayerMask = value; }
+    }
+    [SerializeField]
+    private int _LayerMask;
+
+    public QueryTriggerInteraction QueryTriggerInteraction
+    {
+        get { return _QueryTriggerInteraction; }
+        set { _QueryTriggerInteraction = value; }
+    }
+    [SerializeField]
+    private QueryTriggerInteraction _QueryTriggerInteraction;
+
     /// A Mesh that represents the "Selectable" area of the world.  This is converted from Unity's NavMesh in ViveNavMeshEditor
     public Mesh SelectableMesh
     {
@@ -77,6 +93,8 @@ public class ViveNavMesh : MonoBehaviour
 #if UNITY_EDITOR
         UnityEditor.SceneView.RepaintAll();
 #endif
+        _LayerMask = UnityEngine.LayerMask.NameToLayer("Interaction");
+        _QueryTriggerInteraction = QueryTriggerInteraction.Ignore;
     }
 
     void Update ()
@@ -168,7 +186,7 @@ public class ViveNavMesh : MonoBehaviour
         Vector3 dir = p2 - p1;
         float dist = dir.magnitude;
         dir /= dist;
-        if(Physics.Raycast(p1, dir, out hit, dist))
+        if(Physics.Raycast(p1, dir, out hit, dist, _LayerMask, _QueryTriggerInteraction))
         {
             if(Vector3.Dot(Vector3.up, hit.normal) < 0.99f)
             {

--- a/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
+++ b/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
@@ -48,7 +48,7 @@ public class ViveNavMesh : MonoBehaviour
         set { _IgnoreLayerMask = value; }
     }
     [SerializeField]
-    private bool _IgnoreLayerMask;
+    private bool _IgnoreLayerMask = true;
 
     public int QueryTriggerInteraction
     {

--- a/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
+++ b/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
@@ -42,6 +42,13 @@ public class ViveNavMesh : MonoBehaviour
     }
     [SerializeField]
     private int _LayerMask = 0;
+    public bool IgnoreLayerMask
+    {
+        get { return _IgnoreLayerMask; }
+        set { _IgnoreLayerMask = value; }
+    }
+    [SerializeField]
+    private bool _IgnoreLayerMask;
 
     public int QueryTriggerInteraction
     {
@@ -184,7 +191,7 @@ public class ViveNavMesh : MonoBehaviour
         Vector3 dir = p2 - p1;
         float dist = dir.magnitude;
         dir /= dist;
-        if(Physics.Raycast(p1, dir, out hit, dist, _LayerMask, (QueryTriggerInteraction) _QueryTriggerInteraction))
+        if(Physics.Raycast(p1, dir, out hit, dist, _IgnoreLayerMask ? ~_LayerMask : _LayerMask, (QueryTriggerInteraction) _QueryTriggerInteraction))
         {
             if(Vector3.Dot(Vector3.up, hit.normal) < 0.99f)
             {

--- a/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
+++ b/Assets/Vive-Teleporter/Scripts/ViveNavMesh.cs
@@ -93,8 +93,6 @@ public class ViveNavMesh : MonoBehaviour
 #if UNITY_EDITOR
         UnityEditor.SceneView.RepaintAll();
 #endif
-        _LayerMask = UnityEngine.LayerMask.NameToLayer("Interaction");
-        _QueryTriggerInteraction = QueryTriggerInteraction.Ignore;
     }
 
     void Update ()
@@ -186,7 +184,7 @@ public class ViveNavMesh : MonoBehaviour
         Vector3 dir = p2 - p1;
         float dist = dir.magnitude;
         dir /= dist;
-        if(Physics.Raycast(p1, dir, out hit, dist, _LayerMask, _QueryTriggerInteraction))
+        if(Physics.Raycast(p1, dir, out hit, dist, _LayerMask, (QueryTriggerInteraction) _QueryTriggerInteraction))
         {
             if(Vector3.Dot(Vector3.up, hit.normal) < 0.99f)
             {

--- a/Assets/Vive-Teleporter/Scripts/ViveNavMeshEditor.cs
+++ b/Assets/Vive-Teleporter/Scripts/ViveNavMeshEditor.cs
@@ -14,6 +14,7 @@ public class ViveNavMeshEditor : Editor {
     private SerializedProperty p_material;
     private SerializedProperty p_alpha;
     private SerializedProperty p_layer_mask;
+    private SerializedProperty p_ignore_layer_mask;
     private SerializedProperty p_query_trigger_interaction;
 
     void OnEnable()
@@ -23,6 +24,7 @@ public class ViveNavMeshEditor : Editor {
         p_material = serializedObject.FindProperty("_GroundMaterial");
         p_alpha = serializedObject.FindProperty("GroundAlpha");
         p_layer_mask = serializedObject.FindProperty("_LayerMask");
+        p_ignore_layer_mask = serializedObject.FindProperty("_IgnoreLayerMask");
         p_query_trigger_interaction = serializedObject.FindProperty("_QueryTriggerInteraction");
     }
 
@@ -145,12 +147,20 @@ public class ViveNavMeshEditor : Editor {
         EditorGUILayout.LabelField("Raycast Settings", EditorStyles.boldLabel);
 
         int temp_layer_mask = p_layer_mask.intValue;
+        bool temp_ignore_layer_mask = p_ignore_layer_mask.boolValue;
 
         EditorGUI.BeginChangeCheck();
         temp_layer_mask = EditorGUILayout.LayerField("Layer Mask", temp_layer_mask);
         if(EditorGUI.EndChangeCheck())
         {
             p_layer_mask.intValue = temp_layer_mask;
+        }
+        serializedObject.ApplyModifiedProperties();
+        EditorGUI.BeginChangeCheck();
+        temp_ignore_layer_mask = EditorGUILayout.Toggle("Ignore Layer Mask", temp_ignore_layer_mask);
+        if(EditorGUI.EndChangeCheck())
+        {
+            p_ignore_layer_mask.boolValue = temp_ignore_layer_mask;
         }
         serializedObject.ApplyModifiedProperties();
 

--- a/Assets/Vive-Teleporter/Scripts/ViveNavMeshEditor.cs
+++ b/Assets/Vive-Teleporter/Scripts/ViveNavMeshEditor.cs
@@ -136,6 +136,12 @@ public class ViveNavMeshEditor : Editor {
 
         EditorGUILayout.PropertyField(p_alpha);
         serializedObject.ApplyModifiedProperties();
+
+        // Raycast Settings //
+        EditorGUILayout.LabelField("Raycast Settings", EditorStyles.boldLabel);
+
+        EditorGUILayout.LayerField("Layer", LayerMask.NameToLayer("Default"));
+        EditorGUILayout.EnumMaskField("Trigger", QueryTriggerInteraction.Ignore);
     }
 
     /// \brief Modifies the given NavMesh so that only the Navigation areas are present in the mesh.  This is done only 

--- a/Assets/Vive-Teleporter/Scripts/ViveNavMeshEditor.cs
+++ b/Assets/Vive-Teleporter/Scripts/ViveNavMeshEditor.cs
@@ -14,6 +14,7 @@ public class ViveNavMeshEditor : Editor {
     private SerializedProperty p_material;
     private SerializedProperty p_alpha;
     private SerializedProperty p_layer_mask;
+    private SerializedProperty p_query_trigger_interaction;
 
     void OnEnable()
     {
@@ -22,6 +23,7 @@ public class ViveNavMeshEditor : Editor {
         p_material = serializedObject.FindProperty("_GroundMaterial");
         p_alpha = serializedObject.FindProperty("GroundAlpha");
         p_layer_mask = serializedObject.FindProperty("_LayerMask");
+        p_query_trigger_interaction = serializedObject.FindProperty("_QueryTriggerInteraction");
     }
 
     public override void OnInspectorGUI()
@@ -145,11 +147,20 @@ public class ViveNavMeshEditor : Editor {
         int temp_layer_mask = p_layer_mask.intValue;
 
         EditorGUI.BeginChangeCheck();
-        temp_layer_mask = EditorGUILayout.LayerField("Layer", temp_layer_mask);
+        temp_layer_mask = EditorGUILayout.LayerField("Layer Mask", temp_layer_mask);
         if(EditorGUI.EndChangeCheck())
         {
-            Debug.Log(temp_layer_mask);
             p_layer_mask.intValue = temp_layer_mask;
+        }
+        serializedObject.ApplyModifiedProperties();
+
+        QueryTriggerInteraction temp_query_trigger_interaction = (QueryTriggerInteraction) p_query_trigger_interaction.intValue;
+
+        EditorGUI.BeginChangeCheck();
+        temp_query_trigger_interaction = (QueryTriggerInteraction) EditorGUILayout.EnumPopup("Query Trigger Interaction", (QueryTriggerInteraction) temp_query_trigger_interaction);
+        if(EditorGUI.EndChangeCheck())
+        {
+            p_query_trigger_interaction.intValue = (int) temp_query_trigger_interaction;
         }
         serializedObject.ApplyModifiedProperties();
     }

--- a/Assets/Vive-Teleporter/Scripts/ViveNavMeshEditor.cs
+++ b/Assets/Vive-Teleporter/Scripts/ViveNavMeshEditor.cs
@@ -13,6 +13,7 @@ public class ViveNavMeshEditor : Editor {
     private SerializedProperty p_mesh;
     private SerializedProperty p_material;
     private SerializedProperty p_alpha;
+    private SerializedProperty p_layer_mask;
 
     void OnEnable()
     {
@@ -20,6 +21,7 @@ public class ViveNavMeshEditor : Editor {
         p_mesh = serializedObject.FindProperty("_SelectableMesh");
         p_material = serializedObject.FindProperty("_GroundMaterial");
         p_alpha = serializedObject.FindProperty("GroundAlpha");
+        p_layer_mask = serializedObject.FindProperty("_LayerMask");
     }
 
     public override void OnInspectorGUI()
@@ -140,8 +142,16 @@ public class ViveNavMeshEditor : Editor {
         // Raycast Settings //
         EditorGUILayout.LabelField("Raycast Settings", EditorStyles.boldLabel);
 
-        EditorGUILayout.LayerField("Layer", LayerMask.NameToLayer("Default"));
-        EditorGUILayout.EnumMaskField("Trigger", QueryTriggerInteraction.Ignore);
+        int temp_layer_mask = p_layer_mask.intValue;
+
+        EditorGUI.BeginChangeCheck();
+        temp_layer_mask = EditorGUILayout.LayerField("Layer", temp_layer_mask);
+        if(EditorGUI.EndChangeCheck())
+        {
+            Debug.Log(temp_layer_mask);
+            p_layer_mask.intValue = temp_layer_mask;
+        }
+        serializedObject.ApplyModifiedProperties();
     }
 
     /// \brief Modifies the given NavMesh so that only the Navigation areas are present in the mesh.  This is done only 


### PR DESCRIPTION
When there are big Trigger area in the scene (see the screenshot below), you can't teleport inside them. When doing the Raycast, the Triggers aren't ignored.

The fix was to add 2 parameters to the Raycast method, the LayerMask and the QueryTriggerInteraction.

Before
![2016-10-14 12_05_13](https://cloud.githubusercontent.com/assets/1218149/19394296/866f33ce-9206-11e6-9fab-6fd5a8d52b39.gif)

After
![2016-10-14 12_07_30](https://cloud.githubusercontent.com/assets/1218149/19394349/d05c6c22-9206-11e6-8a8c-005e2767b4f8.gif)

![2016-10-14 12_09_38](https://cloud.githubusercontent.com/assets/1218149/19394411/1b9757e2-9207-11e6-9ce3-9116863c2c45.gif)

You can now tweak the Raycast settings by specifying a Layer Mask, decided to ignore it or not and choose to ignore the Trigger or not.

![capture1](https://cloud.githubusercontent.com/assets/1218149/19362831/1d772f8a-9156-11e6-9383-b5350904079b.PNG)
